### PR TITLE
Add Jinja filters, globals, and tests to environment if available

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Releast type: patch
+
+Add custom Jinja filters, globals, and tests to the jinja2content environment.

--- a/pelican/plugins/jinja2content/jinja2content.py
+++ b/pelican/plugins/jinja2content/jinja2content.py
@@ -38,6 +38,12 @@ class JinjaContentMixin:
                 "extensions": self.settings["JINJA_EXTENSIONS"],
             }
         self.env = Environment(loader=ChoiceLoader(loaders), **jinja_environment)
+        if "JINJA_FILTERS" in self.settings:
+            self.env.filters.update(self.settings["JINJA_FILTERS"])
+        if "JINJA_GLOBALS" in self.settings:
+            self.env.globals.update(self.settings["JINJA_GLOBALS"])
+        if "JINJA_TEST" in self.settings:
+            self.env.tests.update(self.settings["JINJA_TESTS"])
 
     def read(self, source_path):
         with pelican_open(source_path) as text:


### PR DESCRIPTION
Users can add custom Jinja filters with the `JINJA_FILTERS` setting in their settings file. This PR makes the jinja2content Jinja environment respect those filters too.