### PR TITLE
Require Python 3.8+

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,57 +8,60 @@ on:
 
 
 jobs:
-
   lint:
     name: Lint
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+
       - name: Validate links in Markdown files
         uses: JustinBeckwith/linkinator-action@v1
         with:
           retry: true
+
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.x"
+          python-version: "3.9"
+
       - name: Set Poetry cache
         uses: actions/cache@v2
         id: poetry-cache
         with:
           path: ~/.cache/pypoetry/virtualenvs
           key: poetry-${{ hashFiles('**/poetry.lock') }}
-      - name: Upgrade Pip
-        run: python -m pip install --upgrade pip
+
       - name: Install Poetry
         run: python -m pip install poetry
+
       - name: Install dependencies
         run: |
-          poetry run pip install --upgrade pip
-          poetry install
-      - name: Run linters
-        run: poetry run invoke lint
+          poetry install --no-interaction
 
+      - name: Run linters
+        run: poetry run invoke lint --diff
 
   deploy:
     name: Deploy
-    needs: [lint]
+    needs: lint
     runs-on: ubuntu-latest
-    if: ${{ github.ref=='refs/heads/main' && github.event_name!='pull_request' }}
+    if: github.ref=='refs/heads/main' && github.event_name!='pull_request'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.7"
+          python-version: "3.9"
+
       - name: Check release
         id: check_release
         run: |
           python -m pip install --upgrade pip
-          python -m pip install poetry githubrelease httpx==0.16.1 autopub
-          echo "##[set-output name=release;]$(autopub check)"
+          python -m pip install poetry githubrelease httpx==0.18.2 autopub
+          echo "release=$(autopub check)" >> $GITHUB_OUTPUT
       - name: Publish
         if: ${{ steps.check_release.outputs.release=='' }}
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,4 +38,4 @@ repos:
     rev: v2.29.1
     hooks:
       - id: pyupgrade
-        args: [--py36-plus]
+        args: [--py38-plus]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for info on hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.4.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
@@ -18,7 +18,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/psf/black
-    rev: 21.11b0
+    rev: 23.3.0
     hooks:
       - id: black
 
@@ -30,12 +30,12 @@ repos:
         language_version: python3
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.29.1
+    rev: v3.3.1
     hooks:
       - id: pyupgrade
         args: [--py38-plus]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,7 @@
 ---
+ci:
+  autoupdate_schedule: quarterly
+
 # See https://pre-commit.com/hooks.html for info on hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -39,3 +42,9 @@ repos:
     hooks:
       - id: pyupgrade
         args: [--py38-plus]
+
+  - repo: https://github.com/hakancelikdev/unimport
+    rev: 0.12.3
+    hooks:
+      - id: unimport
+        args: [--remove, --include-star-import]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,3 @@ Add custom Jinja filters, globals, and tests to the jinja2content environment.
 ------------------
 
 Initial release as versioned package distribution.
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Jinja2Content Plugin for Pelican
 
-[![Build Status](https://img.shields.io/github/workflow/status/pelican-plugins/jinja2content/build)](https://github.com/pelican-plugins/jinja2content/actions) [![PyPI Version](https://img.shields.io/pypi/v/pelican-jinja2content)](https://pypi.org/project/pelican-jinja2content/)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/pelican-plugins/jinja2content/main.yml?branch=main)](https://github.com/pelican-plugins/jinja2content/actions) [![PyPI Version](https://img.shields.io/pypi/v/pelican-jinja2content)](https://pypi.org/project/pelican-jinja2content/)
 
 This plugin allows the use of Jinja2 directives inside your Pelican articles and pages.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,11 +33,11 @@ pelican = ">=4.5"
 markdown = {version = ">=3.2", optional = true}
 
 [tool.poetry.dev-dependencies]
-black = {version = "^21.11b0", allow-prereleases = true}
+black = "^23"
 flake8 = "^4.0"
 flake8-black = "^0.2"
-invoke = "^1.3"
-isort = "^5.4"
+invoke = "^2.0"
+isort = "^5.12.0"
 livereload = "^2.6"
 markdown = "^3.2"
 pytest = "^6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 "Issue Tracker" = "https://github.com/pelican-plugins/jinja2content/issues"
 
 [tool.poetry.dependencies]
-python = ">=3.6.2,<4.0"
+python = ">=3.8.1,<4.0"
 pelican = ">=4.5"
 markdown = {version = ">=3.2", optional = true}
 


### PR DESCRIPTION
- Require Python 3.8+
- Update linter dependency versions
- Add Unimport hook to pre-commit configuration
- Enhance GitHub Actions CI workflow
- Fix build status badge
